### PR TITLE
Added note in Programming Notes section that a process must call fflu…

### DIFF
--- a/MultiLangProgGuide/MultiLangProgGuide.rst
+++ b/MultiLangProgGuide/MultiLangProgGuide.rst
@@ -1775,6 +1775,17 @@ functionality (see `Utility Functions`_).
 As the M language subsystem uses SIGUSR1 for asynchronous interrupts,
 we strongly suggest that C applications use SIGUSR2 for this purpose.
 
+Forking
+=======
+
+As noted in the `Overview`_, the YottaDB database engine resides in
+the address space of the process. In order to ensure a clean
+separation between parent and child processes:
+
+- Before a process executes ``fork()``, it must execute ``fflush()``.
+- After a ``fork()``, the child process must immediately execute
+  `ydb_child_init()`_ .
+
 Threads
 =======
 

--- a/MultiLangProgGuide/MultiLangProgGuide.rst
+++ b/MultiLangProgGuide/MultiLangProgGuide.rst
@@ -1778,13 +1778,21 @@ we strongly suggest that C applications use SIGUSR2 for this purpose.
 Forking
 =======
 
-As noted in the `Overview`_, the YottaDB database engine resides in
-the address space of the process. In order to ensure a clean
-separation between parent and child processes:
+There are two considerations when executing ``fork()``.
 
-- Before a process executes ``fork()``, it must execute ``fflush()``.
+- Before a process that performs buffered IO executes ``fork()``, it
+  should execute ``fflush()``. Otherwise, the child process will
+  inherit unflushed buffers from the parent, which the child process
+  will flush when it executes an ``fflush()``. This is a general
+  programming admonition, not specific to YottaDB except to the extent
+  that M code within a parent process may have executed ``write``
+  commands which are still buffered when C code within the same
+  process calls ``fork()``.
 - After a ``fork()``, the child process must immediately execute
-  `ydb_child_init()`_ .
+  `ydb_child_init()`_ . Since the YottaDB database engine resides in
+  the address space of the process, as noted in the `Overview`_, this
+  is required to ensure a clean separation in the internal state of
+  the database engine between parent and child processes.
 
 Threads
 =======


### PR DESCRIPTION
…sh() before fork() and a child must call ydb_child_init() immediately after a fork().