### PR TITLE
Correct spacing in EP12 program

### DIFF
--- a/ProgGuide/errproc.rst
+++ b/ProgGuide/errproc.rst
@@ -446,7 +446,7 @@ Example:
            ;N $ZT S $ZT="W !,"CAN'T TAKE RECIPROCAL OF 0"",*7"
            USE $P:(EXCEPTION="D BYE":CTRAP=$C(3))
            WRITE !,"TYPE <CTRL-C> TO STOP"
-   LOOP    FOR DO
+   LOOP    FOR  DO
            . READ !,"TYPE A NUMBER: ",X
            . WRITE ?20,"HAS RECIPROCAL OF: ",1/X
            . QUIT


### PR DESCRIPTION
There needs to be two spaces after a FOR command before a DO block
if there are no arguments to the FOR command.