### PR TITLE
Library link flag has to be at the end of the gcc command

### DIFF
--- a/MultiLangProgGuide/MultiLangProgGuide.rst
+++ b/MultiLangProgGuide/MultiLangProgGuide.rst
@@ -60,15 +60,14 @@ Local Installation
    <https://raw.githubusercontent.com/YottaDB/YottaDBtest/master/simpleapi/outref/wordfreq_input.txt>`_
    and `corresponding reference output file
    <https://raw.githubusercontent.com/YottaDB/YottaDBtest/master/simpleapi/outref/wordfreq_output.txt>`_
-   and compile it with :code:`gcc -I $ydb_dist -L
-   $ydb_dist -lyottadb -o wordfreq wordfreq.c`.
+   and compile it with :code:`gcc -I $ydb_dist -L $ydb_dist -o wordfreq wordfreq.c -lyottadb`.
 
 #. Run your program and verify that the output matches the reference output. For example:
 
 .. code-block:: bash
 
 	$ cd $ydb_dir
-	$ gcc -I $ydb_dist -L $ydb_dist -lyottadb -o wordfreq wordfreq.c
+	$ gcc -I $ydb_dist -L $ydb_dist -o wordfreq wordfreq.c -lyottadb
 	$ ./wordfreq <wordfreq_input.txt >wordfreq_output.tmp
 	$ diff wordfreq_output.tmp wordfreq_output.txt 
 	$


### PR DESCRIPTION
Otherwise, you get this:

/tmp/ccVGAIj3.o: In function `main':
wordfreq.c:(.text+0xa5): undefined reference to `ydb_delete_s'
wordfreq.c:(.text+0xe4): undefined reference to `ydb_delete_s'
wordfreq.c:(.text+0x228): undefined reference to `ydb_incr_s'
wordfreq.c:(.text+0x283): undefined reference to `ydb_fork_n_core'
wordfreq.c:(.text+0x33c): undefined reference to `ydb_subscript_next_s'
wordfreq.c:(.text+0x397): undefined reference to `ydb_fork_n_core'
wordfreq.c:(.text+0x3d2): undefined reference to `ydb_get_s'
wordfreq.c:(.text+0x42d): undefined reference to `ydb_fork_n_core'
wordfreq.c:(.text+0x491): undefined reference to `ydb_set_s'
wordfreq.c:(.text+0x4f0): undefined reference to `ydb_fork_n_core'
wordfreq.c:(.text+0x51c): undefined reference to `ydb_subscript_previous_s'
wordfreq.c:(.text+0x577): undefined reference to `ydb_fork_n_core'
wordfreq.c:(.text+0x60b): undefined reference to `ydb_subscript_next_s'
wordfreq.c:(.text+0x666): undefined reference to `ydb_fork_n_core'
collect2: error: ld returned 1 exit status